### PR TITLE
Catch JSON parsing error

### DIFF
--- a/gapitoken.js
+++ b/gapitoken.js
@@ -78,15 +78,19 @@ GAPI.prototype.getAccessToken = function(callback) {
         });
 
         res.on('end', function() {
-            d = JSON.parse(d);
-            if (d.error) {
-                self.token = null;
-                self.token_expires = null;
-                callback(d, null);
-            } else {
-                self.token = d.access_token;
-                self.token_expires = iat + 3600;
-                callback(null, self.token);
+            try {
+                d = JSON.parse(d);
+                if (d.error) {
+                    self.token = null;
+                    self.token_expires = null;
+                    callback(d, null);
+                } else {
+                    self.token = d.access_token;
+                    self.token_expires = iat + 3600;
+                    callback(null, self.token);
+                }
+            } catch (e) {
+                callback(e, null);
             }
         });
     }).on('error', function(err) {


### PR DESCRIPTION
Google can something (in outage for example) return HTML(!) page(!!) instead of JSON result. 

When this happens your entire server will crash and you will get the uncaughtException process event which is too high in the responsibility chain to handle the FAIL.
