### PR TITLE
Pass errors to callbacks instead of throwing them

### DIFF
--- a/gapitoken.js
+++ b/gapitoken.js
@@ -24,7 +24,7 @@ var GAPI = function(options, callback) {
         this.key = options.key;
         process.nextTick(callback);
     } else {
-        throw new Error("Missing key, key or keyFile option must be provided!");
+        callback("Missing key, key or keyFile option must be provided!");
     }
 };
 


### PR DESCRIPTION
To make the behaviour consistent across the library, errors should be passed to callbacks instead of throwing them; otherwise it causes some confusion and potentially breaks error handling in other libraries that use this module.

PS. It would be great if you could also release this as a patch update on NPM. Thank you!
