### PR TITLE
Bump jws dep to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"license": "MIT",
 	"readmeFilename": "README.md",
 	"dependencies": {
-		"jws": "0.0.2",
+		"jws": "~3.0.0",
     "request": "^2.54.0"
 	}
 }


### PR DESCRIPTION
Bumps jws dependency to 3.0.0 (anything less than 3.0.0 is deprecated).

Closes #15 